### PR TITLE
Change the command to record the NERDTree root path

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -305,7 +305,7 @@ function! s:check_special_window(session)
   if exists('b:NERDTreeRoot')
     if !has_key(s:nerdtrees, bufnr('%'))
       let command = 'NERDTree'
-      let argument = b:NERDTreeRoot.path.str()
+      let argument = b:NERDTree.root.path.str()
       let s:nerdtrees[bufnr('%')] = 1
     else
       let command = 'NERDTreeMirror'


### PR DESCRIPTION
By using this command a long standing annoyance is finaly solved… With this very small change/fix NERDTree now always opens with the correct path.

Before this patch just 10% of my sessions opened with the correct root path for NERDTree.